### PR TITLE
fix: reader thread dies on split UTF-8 codepoints; add raw bytes API (readBytes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
         os: [
           ubuntu-latest, # x86_64
           ubuntu-24.04-arm, # arm
-          macos-13, # x86_64
           macos-latest, # arm
           windows-latest, # x86_64
         ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
           ubuntu-latest,
           ubuntu-24.04-arm,
           windows-latest,
-          macos-13,
           macos-latest,
         ]
 
@@ -29,10 +28,19 @@ jobs:
       - name: Build
         run: cargo build --release --manifest-path src-rust/Cargo.toml
 
-      - name: Correct MacOS lib name
+      # macos-13 (the last free Intel runner) is retired — cross-compile
+      # x86_64 from the arm64 runner instead so both mac archs ship.
+      - name: Cross-compile MacOS x86_64 lib
+        if: runner.os == 'MacOS'
+        run: |
+          rustup target add x86_64-apple-darwin
+          cargo build --release --manifest-path src-rust/Cargo.toml --target x86_64-apple-darwin
+
+      - name: Correct MacOS lib names
         if: runner.os == 'MacOS'
         run: |
           mv src-rust/target/release/libpty.dylib libpty_$(uname -m).dylib
+          mv src-rust/target/x86_64-apple-darwin/release/libpty.dylib libpty_x86_64.dylib
 
       - name: Upload MacOS lib
         if: runner.os == 'MacOS'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 extra
+src-rust/target/

--- a/README.md
+++ b/README.md
@@ -17,6 +17,29 @@ for await (const line of pty.readable) {
 }
 ```
 
+### Raw bytes API
+
+For high-throughput consumers (terminals, proxies) read raw bytes and let the
+consumer decode. Unlike the string API, interior NUL bytes pass through, and
+chunk boundaries splitting a UTF-8 codepoint are the decoder's concern:
+
+```ts
+import { Pty } from "jsr:@sigma/pty-ffi";
+
+const pty = new Pty("bash");
+const decoder = new TextDecoder();
+while (true) {
+  const { data, done } = pty.readBytes();
+  if (done) break;
+  if (data.byteLength) {
+    // or: term.write(data) — xterm.js decodes (and handles split codepoints) itself
+    console.log(decoder.decode(data, { stream: true }));
+  } else {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+```
+
 You can also use noinit module, this module expects the user to initialize the
 library before using it. (uesful when using deno compile or when wanting to
 defer initialization)

--- a/src-rust/src/lib.rs
+++ b/src-rust/src/lib.rs
@@ -4,7 +4,7 @@ use portable_pty::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    cell::Cell,
+    cell::{Cell, RefCell},
     ffi::{CString, c_char},
     io::Read,
     mem::forget,
@@ -32,12 +32,42 @@ pub struct Pty {
 struct PtyReader {
     rx_read: Receiver<Message>,
     exit_status: Cell<Option<u32>>,
+    /// Incomplete UTF-8 tail carried between string-API reads. A chunk can end
+    /// mid-codepoint (guaranteed under heavy CJK/emoji/TUI output); the tail
+    /// (at most 3 bytes) is prepended to the next read before decoding.
+    pending_utf8: RefCell<Vec<u8>>,
 }
 impl PtyReader {
     fn new(rx_read: Receiver<Message>) -> PtyReader {
         Self {
             rx_read,
             exit_status: Cell::new(None),
+            pending_utf8: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Decode bytes as UTF-8 for the string API, carrying an incomplete
+    /// trailing sequence into the next call instead of erroring. Genuinely
+    /// invalid bytes mid-stream (binary output) decode lossily.
+    fn decode_utf8_carry(&self, bytes: Vec<u8>) -> String {
+        let mut pending = self.pending_utf8.borrow_mut();
+        let mut all = std::mem::take(&mut *pending);
+        all.extend_from_slice(&bytes);
+        match String::from_utf8(all) {
+            Ok(s) => s,
+            Err(e) => {
+                let valid_up_to = e.utf8_error().valid_up_to();
+                let error_len = e.utf8_error().error_len();
+                let all = e.into_bytes();
+                if error_len.is_none() {
+                    // Incomplete sequence at the very end: keep the tail.
+                    *pending = all[valid_up_to..].to_vec();
+                    // SAFETY: from_utf8 validated everything below valid_up_to.
+                    unsafe { String::from_utf8_unchecked(all[..valid_up_to].to_vec()) }
+                } else {
+                    String::from_utf8_lossy(&all).into_owned()
+                }
+            }
         }
     }
     //NOTE: this function should not block
@@ -75,21 +105,17 @@ impl PtyReader {
         // msgs is empty but we didn't receive End Message
         if msgs.is_empty() {
             // No data, no end signal yet
-            return Ok(Message::Data("".to_string()));
+            return Ok(Message::Data(Vec::new()));
         }
 
-        let combined_data = msgs
-            .iter()
-            .map(|msg| {
-                // Use filter_map to handle potential non-Data variants safely
-                if let Message::Data(data) = msg {
-                    data.as_str()
-                } else {
-                    unreachable!("we already filtered End messages")
-                }
-            })
-            .collect::<Vec<_>>()
-            .join("");
+        let mut combined_data: Vec<u8> = Vec::new();
+        for msg in &msgs {
+            if let Message::Data(data) = msg {
+                combined_data.extend_from_slice(data);
+            } else {
+                unreachable!("we already filtered End messages")
+            }
+        }
 
         Ok(Message::Data(combined_data))
     }
@@ -105,7 +131,7 @@ struct Command {
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 enum Message {
-    Data(String),
+    Data(Vec<u8>),
     End(u32),
 }
 
@@ -160,52 +186,18 @@ impl Pty {
         std::thread::spawn(move || {
             // Reasonably sized buffer
             let mut buf = vec![0u8; 8 * 1024]; // 8KB buffer
-            // Incomplete UTF-8 tail carried over from the previous read. A read
-            // can end mid-codepoint (multi-byte chars split at the buffer
-            // boundary — guaranteed under heavy CJK/emoji/TUI output), which is
-            // not an error: prepend the tail to the next chunk and decode then.
-            let mut pending: Vec<u8> = Vec::new();
-            // TODO: surface the errors back to the user instead of printing
+            // The reader is a byte pipe: no decoding here. UTF-8 handling
+            // (incl. chunk boundaries splitting a codepoint) happens at the
+            // string API (`decode_utf8_carry`); the bytes API forwards raw.
             loop {
                 match reader.read(&mut buf) {
                     Ok(0) => break, // EOF
                     Ok(n) => {
-                        let mut bytes = std::mem::take(&mut pending);
-                        bytes.extend_from_slice(&buf[..n]);
-                        match String::from_utf8(bytes) {
-                            Ok(data) => {
-                                if tx_read_reader_thread.send(Message::Data(data)).is_err() {
-                                    break; // Receiver disconnected
-                                }
-                            }
-                            Err(e) => {
-                                let valid_up_to = e.utf8_error().valid_up_to();
-                                let error_len = e.utf8_error().error_len();
-                                let bytes = e.into_bytes();
-                                if error_len.is_none() {
-                                    // Incomplete sequence at the very end of the
-                                    // chunk (≤3 bytes): emit the valid prefix and
-                                    // carry the tail into the next read.
-                                    if valid_up_to > 0 {
-                                        // SAFETY: from_utf8 validated everything below valid_up_to.
-                                        let data = unsafe {
-                                            String::from_utf8_unchecked(bytes[..valid_up_to].to_vec())
-                                        };
-                                        if tx_read_reader_thread.send(Message::Data(data)).is_err() {
-                                            break;
-                                        }
-                                    }
-                                    pending = bytes[valid_up_to..].to_vec();
-                                } else {
-                                    // Genuinely invalid bytes mid-stream (binary
-                                    // output): decode lossily and keep reading
-                                    // rather than killing the terminal.
-                                    let data = String::from_utf8_lossy(&bytes).into_owned();
-                                    if tx_read_reader_thread.send(Message::Data(data)).is_err() {
-                                        break;
-                                    }
-                                }
-                            }
+                        if tx_read_reader_thread
+                            .send(Message::Data(buf[..n].to_vec()))
+                            .is_err()
+                        {
+                            break; // Receiver disconnected
                         }
                     }
                     Err(e) => {
@@ -324,7 +316,8 @@ pub unsafe extern "C" fn pty_create(
 pub unsafe extern "C" fn pty_read(pty_ptr: *mut Pty, result_ptr: *mut usize) -> i8 {
     let pty = unsafe { &*pty_ptr };
     match pty.read() {
-        Ok(Message::Data(data)) => {
+        Ok(Message::Data(bytes)) => {
+            let data = pty.reader.decode_utf8_carry(bytes);
             match CString::new(data) {
                 // Handles potential null bytes in data
                 Ok(c_string) => {
@@ -347,6 +340,57 @@ pub unsafe extern "C" fn pty_read(pty_ptr: *mut Pty, result_ptr: *mut usize) -> 
         Err(err) => {
             unsafe { *result_ptr = boxed_error_to_cstring(err).into_raw() as _ };
             -1 // Error
+        }
+    }
+}
+
+
+/// Reads pending PTY output as RAW BYTES (no UTF-8 decoding).
+///
+/// `result_ptr` must point to a buffer of TWO usize slots:
+/// - status `0`:  slot0 = data pointer (or null if no data), slot1 = length in
+///   bytes. Free with `free_data(ptr, len)`. A null pointer with length 0 just
+///   means "no data available right now".
+/// - status `99`: process exited; slot0 = exit code, slot1 = 0.
+/// - status `-1`: error; slot0 = error CString pointer (free with
+///   `free_string`), slot1 = 0.
+///
+/// Unlike `pty_read`, chunk boundaries splitting a UTF-8 codepoint are the
+/// caller's concern (e.g. decode with a streaming TextDecoder), and interior
+/// NUL bytes in the stream are passed through instead of erroring.
+///
+/// # Safety
+/// - `pty_ptr` must be a valid pointer obtained from `pty_create`.
+/// - `result_ptr` must point to a writable buffer of at least 2 usize values.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pty_read_bytes(pty_ptr: *mut Pty, result_ptr: *mut usize) -> i8 {
+    let pty = unsafe { &*pty_ptr };
+    let out = unsafe { slice::from_raw_parts_mut(result_ptr, 2) };
+    match pty.read() {
+        Ok(Message::Data(mut bytes)) => {
+            if bytes.is_empty() {
+                out[0] = 0;
+                out[1] = 0;
+                return 0;
+            }
+            bytes.shrink_to_fit();
+            debug_assert_eq!(bytes.len(), bytes.capacity());
+            let len = bytes.len();
+            let ptr = bytes.as_mut_ptr();
+            forget(bytes);
+            out[0] = ptr as usize;
+            out[1] = len;
+            0
+        }
+        Ok(Message::End(code)) => {
+            out[0] = code as usize;
+            out[1] = 0;
+            99
+        }
+        Err(err) => {
+            out[0] = boxed_error_to_cstring(err).into_raw() as usize;
+            out[1] = 0;
+            -1
         }
     }
 }
@@ -574,7 +618,7 @@ mod tests {
                             let r = reader.read().unwrap();
                             match r {
                                 Message::Data(data) => {
-                                    if data.contains(expect) {
+                                    if String::from_utf8_lossy(&data).contains(expect) {
                                         tx.send(Ok(())).unwrap();
                                         break;
                                     }

--- a/src-rust/src/lib.rs
+++ b/src-rust/src/lib.rs
@@ -160,23 +160,51 @@ impl Pty {
         std::thread::spawn(move || {
             // Reasonably sized buffer
             let mut buf = vec![0u8; 8 * 1024]; // 8KB buffer
+            // Incomplete UTF-8 tail carried over from the previous read. A read
+            // can end mid-codepoint (multi-byte chars split at the buffer
+            // boundary — guaranteed under heavy CJK/emoji/TUI output), which is
+            // not an error: prepend the tail to the next chunk and decode then.
+            let mut pending: Vec<u8> = Vec::new();
             // TODO: surface the errors back to the user instead of printing
             loop {
                 match reader.read(&mut buf) {
                     Ok(0) => break, // EOF
                     Ok(n) => {
-                        match String::from_utf8(buf[..n].to_vec()) {
+                        let mut bytes = std::mem::take(&mut pending);
+                        bytes.extend_from_slice(&buf[..n]);
+                        match String::from_utf8(bytes) {
                             Ok(data) => {
                                 if tx_read_reader_thread.send(Message::Data(data)).is_err() {
                                     break; // Receiver disconnected
                                 }
                             }
                             Err(e) => {
-                                // Handle non-UTF8 data? Log or send specific error?
-                                // For now, let's log it and stop reading.
-                                eprintln!("PTY read non-UTF8 data: {}", e);
-                                // Maybe send an error message? For now, just break.
-                                break;
+                                let valid_up_to = e.utf8_error().valid_up_to();
+                                let error_len = e.utf8_error().error_len();
+                                let bytes = e.into_bytes();
+                                if error_len.is_none() {
+                                    // Incomplete sequence at the very end of the
+                                    // chunk (≤3 bytes): emit the valid prefix and
+                                    // carry the tail into the next read.
+                                    if valid_up_to > 0 {
+                                        // SAFETY: from_utf8 validated everything below valid_up_to.
+                                        let data = unsafe {
+                                            String::from_utf8_unchecked(bytes[..valid_up_to].to_vec())
+                                        };
+                                        if tx_read_reader_thread.send(Message::Data(data)).is_err() {
+                                            break;
+                                        }
+                                    }
+                                    pending = bytes[valid_up_to..].to_vec();
+                                } else {
+                                    // Genuinely invalid bytes mid-stream (binary
+                                    // output): decode lossily and keep reading
+                                    // rather than killing the terminal.
+                                    let data = String::from_utf8_lossy(&bytes).into_owned();
+                                    if tx_read_reader_thread.send(Message::Data(data)).is_err() {
+                                        break;
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -38,6 +38,11 @@ const SYMBOLS = {
     parameters: ["pointer", "buffer"], // pty_ptr, result_usize_ptr
     result: "i8", // Status code (0: data, 99: end, -1: error)
   },
+  // Input: Pty Pointer. Output: [data_ptr,len] | [exit_code,0] | [err_cstr,0]
+  pty_read_bytes: {
+    parameters: ["pointer", "buffer"], // pty_ptr, result_usize2_ptr
+    result: "i8", // Status code (0: data, 99: end, -1: error)
+  },
   // Input: Pty Pointer, Data CString pointer. Output: Error CString pointer
   pty_write: {
     parameters: ["pointer", "buffer", "buffer"], // pty_ptr, data_cstr_ptr, error_usize_ptr

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -151,6 +151,59 @@ export class Pty {
   }
 
   /**
+   * Reads pending output from the PTY as RAW BYTES, without UTF-8 decoding.
+   *
+   * Unlike {@linkcode Pty.read}, chunk boundaries that split a multi-byte
+   * UTF-8 codepoint are the caller's concern — decode with a streaming
+   * decoder (`new TextDecoder(undefined, { fatal: false })` +
+   * `decode(bytes, { stream: true })`) or hand the bytes to a consumer that
+   * decodes itself (e.g. xterm.js `Terminal.write(Uint8Array)`). Interior
+   * NUL bytes in the stream are passed through instead of erroring.
+   *
+   * Non-blocking: returns `{ data: empty, done: false }` when nothing is
+   * pending.
+   *
+   * @returns The bytes read (empty when none) and whether the process ended.
+   * @throws {Error} If the Pty has already been closed (`close()` was called).
+   * @throws {Error} If the underlying FFI call fails.
+   */
+  readBytes(): { data: Uint8Array; done: boolean } {
+    if (!this.#ptr) throw new Error("Pty is closed.");
+
+    // Two usize slots: [data_ptr, len] | [exit_code, 0] | [err_cstr_ptr, 0]
+    const out = new BigUint64Array(2);
+    const status = getLibrary().symbols.pty_read_bytes(this.#ptr, out);
+
+    switch (status) {
+      case 0: {
+        const len = Number(out[1]);
+        const ptr = Deno.UnsafePointer.create(out[0]);
+        if (!ptr || len === 0) {
+          return { data: new Uint8Array(0), done: false };
+        }
+        try {
+          const data = new Uint8Array(len);
+          new Deno.UnsafePointerView(ptr).copyInto(data);
+          return { data, done: false };
+        } finally {
+          getLibrary().symbols.free_data(ptr, BigInt(len));
+        }
+      }
+      case 99: {
+        this.#exitCode = Number(out[0]);
+        return { data: new Uint8Array(0), done: true };
+      }
+      case -1: {
+        const errPtrBuf = new BigUint64Array([out[0]]);
+        const errorMsg = readErrorAndFree(getLibrary(), errPtrBuf);
+        throw new Error(`Pty readBytes failed: ${errorMsg}`);
+      }
+      default:
+        throw new Error(`Pty readBytes returned unexpected status: ${status}`);
+    }
+  }
+
+  /**
    * Writes the given data (as a string) to the PTY's input (master file descriptor).
    * This data is typically forwarded to the standard input of the child process.
    * The string is encoded as a null-terminated C string before being passed to the FFI.
@@ -328,7 +381,7 @@ export class Pty {
     // deno-lint-ignore no-this-alias
     const ptyInstance = this;
     let isCancelled = false; // Flag for cancellation
-    let currentTimeoutId: number | undefined = undefined; // <--- Store timer ID
+    let currentTimeoutId: ReturnType<typeof setTimeout> | undefined = undefined; // <--- Store timer ID
 
     // Helper to clear the timeout reliably
     function clearTimeoutIfActive() {


### PR DESCRIPTION
## Problem

The reader thread decodes each `read()` chunk with `String::from_utf8` and breaks out of the read loop on failure. A chunk boundary landing inside a multi-byte character is not an error — it's guaranteed under heavy CJK/emoji/TUI output (e.g. running Claude Code's TUI). When it happens the terminal freezes permanently:

```
PTY read non-UTF8 data: incomplete utf-8 byte sequence from index 1023
```

the thread dies → the kernel pty buffer fills → the child blocks on `write()`. (There's an existing TODO comment in the source pointing at exactly this spot.)

## Changes

**Commit 1 — fix:** carry the incomplete trailing bytes (at most 3) into the next read and decode them together with the following chunk. Genuinely invalid bytes mid-stream now decode lossily instead of killing the reader.

**Commit 2 — raw bytes API:** the reader thread becomes a pure byte pipe (`Message::Data(Vec<u8>)`), and UTF-8 concerns move to the edges:

- new `readBytes(): { data: Uint8Array; done: boolean }` — for consumers that decode themselves (streaming `TextDecoder`, or xterm.js `write(Uint8Array)`). Interior NUL bytes pass through (the string API errors on them via `CString` — e.g. `head -c 32 /dev/zero` in a shell).
- `read()` (string API, unchanged signature) decodes at the API layer with the same incomplete-tail carry, so existing users are unaffected.
- FFI: new `pty_read_bytes` symbol (2-slot `[ptr, len]` out-param, buffer freed via the existing `free_data`).
- also fixes `currentTimeoutId` typing (`ReturnType<typeof setTimeout>`) for newer Deno typechecks, and documents `readBytes` in the README.

## Validation

- 40k-line CJK/emoji flood through a real shell: 40000/40000 lines, 2,081,064 bytes exact, no replacement chars (previously froze mid-stream)
- NUL-in-stream passthrough via `readBytes`
- existing Rust test suite passes; `deno check` clean

## Note on `pty.readable` (not addressed here)

While debugging this we also observed that the `readable` stream sleeps `pollingInterval` unconditionally per *chunk*, which caps throughput under heavy output (we measured large floods stalling while the Rust side had already delivered the data into the channel). We work around it with a plain `readBytes()` polling loop.