### PR TITLE
ci: drop retired macos-13 runner; cross-compile x86_64 dylib on arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
         os: [
           ubuntu-latest, # x86_64
           ubuntu-24.04-arm, # arm
-          macos-13, # x86_64
           macos-latest, # arm
           windows-latest, # x86_64
         ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
           ubuntu-latest,
           ubuntu-24.04-arm,
           windows-latest,
-          macos-13,
           macos-latest,
         ]
 
@@ -29,10 +28,19 @@ jobs:
       - name: Build
         run: cargo build --release --manifest-path src-rust/Cargo.toml
 
-      - name: Correct MacOS lib name
+      # macos-13 (the last free Intel runner) is retired — cross-compile
+      # x86_64 from the arm64 runner instead so both mac archs ship.
+      - name: Cross-compile MacOS x86_64 lib
+        if: runner.os == 'MacOS'
+        run: |
+          rustup target add x86_64-apple-darwin
+          cargo build --release --manifest-path src-rust/Cargo.toml --target x86_64-apple-darwin
+
+      - name: Correct MacOS lib names
         if: runner.os == 'MacOS'
         run: |
           mv src-rust/target/release/libpty.dylib libpty_$(uname -m).dylib
+          mv src-rust/target/x86_64-apple-darwin/release/libpty.dylib libpty_x86_64.dylib
 
       - name: Upload MacOS lib
         if: runner.os == 'MacOS'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 extra
+src-rust/target/

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -328,7 +328,7 @@ export class Pty {
     // deno-lint-ignore no-this-alias
     const ptyInstance = this;
     let isCancelled = false; // Flag for cancellation
-    let currentTimeoutId: number | undefined = undefined; // <--- Store timer ID
+    let currentTimeoutId: ReturnType<typeof setTimeout> | undefined = undefined; // <--- Store timer ID
 
     // Helper to clear the timeout reliably
     function clearTimeoutIfActive() {


### PR DESCRIPTION
GitHub retired `macos-13` (the last free Intel runner), so any job targeting it now queues forever — this currently affects both `release.yml` and the `ci.yml` test matrix here.

- `release.yml`: build the x86_64 dylib on the arm64 runner instead, via `rustup target add x86_64-apple-darwin` + `cargo build --target …`, so both mac archs keep shipping (`libpty_arm64.dylib` + `libpty_x86_64.dylib`).
- `ci.yml`: drop `macos-13` from the matrix. Mac test coverage becomes arm-only; the x86_64 build is still compile-verified by the release job.
- also gitignores `src-rust/target/`.

Ran this exact setup on my fork's Actions — all platforms green, release uploads all 5 binaries.

One operational note: tag-triggered workflows read the yml **at the tag's commit**, so the release fix only takes effect for tags created after this lands (re-pointing an existing tag also works).