### PR TITLE
feat: open the pty at a requested initial size

### DIFF
--- a/src-rust/src/lib.rs
+++ b/src-rust/src/lib.rs
@@ -127,6 +127,7 @@ struct Command {
     args: Option<Vec<String>>,
     env: Option<std::collections::HashMap<String, String>>,
     cwd: Option<String>,
+    size: Option<PtySize>,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -138,12 +139,16 @@ enum Message {
 impl Pty {
     fn create(command: Command) -> Result<Self> {
         let pty_system = native_pty_system();
-        let pair = pty_system.openpty(PtySize {
+        // Open at the requested size so the child never observes the default
+        // grid: with a spawn-then-resize dance the shell can win the race and
+        // print its first prompt at 80 cols, which reflows into stray blank
+        // lines once the real size lands.
+        let pair = pty_system.openpty(command.size.unwrap_or(PtySize {
             rows: 24,
             cols: 80,
             pixel_width: 0,
             pixel_height: 0,
-        })?;
+        }))?;
 
         let mut cmd_builder = CommandBuilder::new(command.cmd);
         // https://github.com/wez/wezterm/issues/4205
@@ -591,6 +596,32 @@ mod tests {
     use std::sync::mpsc;
 
     use super::*;
+
+    #[test]
+    fn spawn_size() {
+        let pty = Pty::create(Command {
+            cmd: if cfg!(windows) { "cmd" } else { "echo" }.into(),
+            args: Some(vec!["hello".into()]),
+            env: None,
+            cwd: None,
+            size: Some(PtySize {
+                rows: 33,
+                cols: 61,
+                pixel_width: 0,
+                pixel_height: 0,
+            }),
+        })
+        .unwrap();
+        assert!(matches!(
+            pty.get_size(),
+            Ok(PtySize {
+                rows: 33,
+                cols: 61,
+                ..
+            })
+        ));
+    }
+
     #[test]
     fn it_works() {
         let mut threads = vec![];
@@ -601,6 +632,7 @@ mod tests {
                     args: Some(vec!["repl".into()]),
                     env: Some([("NO_COLOR".into(), "1".into())].into()),
                     cwd: None,
+                    size: None,
                 })
                 .unwrap();
 

--- a/src/ffi.ts
+++ b/src/ffi.ts
@@ -11,6 +11,13 @@ export interface CommandOptions {
   env?: Record<string, string>;
   /** The working directory for the command. defaults to the current working directory. */
   cwd?: string;
+  /**
+   * The initial terminal size. The pty is opened at this size, so the child
+   * process never observes the default 80x24 grid — spawning at the real size
+   * avoids the resize race where a shell prints its first prompt at 80
+   * columns and reflows it once a later `resize()` lands. Defaults to 80x24.
+   */
+  size?: PtySize;
 }
 
 /**

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -51,7 +51,15 @@ export class Pty {
    */
   constructor(command: string, options: CommandOptions = {}) {
     // 1. Encode command using pointer + length (bincode serialization)
-    const rustCommand = { cmd: command, ...options };
+    // Rust's PtySize deserializes all fields, so fill the optional pixel
+    // dimensions like resize() does.
+    const rustCommand = {
+      cmd: command,
+      ...options,
+      ...(options.size
+        ? { size: { pixel_width: 0, pixel_height: 0, ...options.size } }
+        : {}),
+    };
     const cmdData = encodePointerLenData(rustCommand);
     const cmdDataPtr = Deno.UnsafePointer.of(cmdData); // Get pointer TO the TS buffer containing serialized data
 

--- a/tests/mod.test.ts
+++ b/tests/mod.test.ts
@@ -99,6 +99,32 @@ Deno.test("getSize/resize", () => {
   pty.close();
 });
 
+Deno.test("spawn size", () => {
+  // The pty opens at the requested size — the child never observes the
+  // default 80x24 grid, so there is no spawn-then-resize race.
+  const pty = new Pty(
+    Deno.build.os === "windows" ? "cmd" : "echo",
+    {
+      args: ["hello"],
+      size: { rows: 33, cols: 61 },
+    },
+  );
+  const size = pty.getSize();
+  assertEquals(size.rows, 33);
+  assertEquals(size.cols, 61);
+  pty.close();
+
+  // Without a size the default grid stays 80x24.
+  const def = new Pty(
+    Deno.build.os === "windows" ? "cmd" : "echo",
+    { args: ["hello"] },
+  );
+  const defSize = def.getSize();
+  assertEquals(defSize.rows, 24);
+  assertEquals(defSize.cols, 80);
+  def.close();
+});
+
 Deno.test("with cwd set", async () => {
   const tmpDir = await Deno.makeTempDir();
   const testFileName = "pty_cwd_test_file.txt";


### PR DESCRIPTION
## Motivation

`openpty` is currently called with a hardcoded `PtySize { rows: 24, cols: 80 }`, so the only way to start a shell at the real terminal size is spawn-then-`resize()`. That has an inherent race: a fast shell prints its first prompt at 80 cols before the resize lands, and the prompt reflows into stray blank lines once the real size arrives. We hit this reliably in a terminal panel that spawns shells at ~60 cols.

## Change

- `CommandOptions` gains an optional `size?: PtySize`, passed through `Command` to `openpty` (`portable_pty` already takes a `PtySize` there).
- Defaults are unchanged: no `size` still opens at 80x24.
- The optional `pixel_width`/`pixel_height` are filled on the TS side, same as `resize()` does.

## Tests

- Rust: `spawn_size` — create with `size`, `get_size()` returns it.
- Deno: `spawn size` — spawn size honored, and the no-size default stays 80x24.

`cargo test`, `cargo clippy`, and `deno test -A` (14/14) pass locally on macOS arm64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)